### PR TITLE
Change dependencies for Equip 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
+
+_..._
+
+## 2.0.0 - ?
+
+- Update for compatibility with Equip v2.x

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "equip/framework": "^1.0 || ^2.0"
+        "equip/config": ">=1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0"


### PR DESCRIPTION
The `ConfigurationInterface` has been moved to `equip/config`.